### PR TITLE
Drop nsq lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ENV = NODE_ENV=test
+ENV = NODE_ENV=test DEBUG=nsq-strategies:*
 BIN = ./node_modules/.bin
 TESTS = test/*.test.js
 MOCHA_OPTS = -b --timeout 20000 --reporter spec

--- a/dockers/start.sh
+++ b/dockers/start.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ev
 
-# Require some environment variables. Examples:
-# export NSQ_DOCKERS="cluster"
+# Environment variables.
+NSQ_DOCKERS=${NSQ_DOCKERS:-cluster}
 
 pushd `dirname $0`
 DIR=`pwd`

--- a/dockers/stop.sh
+++ b/dockers/stop.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ev
 
-# Require some environment variables. Examples:
-# export NSQ_DOCKERS="cluster"
+# Environment variables.
+NSQ_DOCKERS=${NSQ_DOCKERS:-cluster}
 
 pushd `dirname $0`
 DIR=`pwd`

--- a/lib/Consumer.js
+++ b/lib/Consumer.js
@@ -6,7 +6,7 @@ const debug = require('debug')('nsq-strategies:lib:consumer');
 class Consumer {
   constructor(topic, channel, options) {
     options = options || {};
-    if (typeof options.autoConnect === 'undefined') {
+    if (options.autoConnect == null) {
       //default is true
       options.autoConnect = true;
     }

--- a/lib/Producer.js
+++ b/lib/Producer.js
@@ -2,9 +2,11 @@
 
 const nsq = require('nsqjs');
 const Promise = require('bluebird');
-const nsqlookup = Promise.promisify(require('nsq-lookup'));
 const promiseRetry = require('promise-retry');
 const debug = require('debug')('nsq-strategies:lib:producer');
+
+const lib = require('./');
+const LookupdCluster = lib.api.LookupdCluster;
 
 class Producer {
 
@@ -16,11 +18,7 @@ class Producer {
       return;
     }
     if (config.lookupdHTTPAddresses) {
-      let addresses = config.lookupdHTTPAddresses;
-      if (!Array.isArray(addresses)) {
-        addresses = [addresses];
-      }
-      this.lookupd = normalizeAddress(addresses);
+      this.lookupdCluster = new LookupdCluster(config.lookupdHTTPAddresses);
       this.counter = 0;
       this.strategy = (options && options.strategy) || Producer.ROUND_ROBIN;
     }
@@ -29,19 +27,11 @@ class Producer {
   connect(callback) {
     this.conns = [];
     this._closed = false;
-    if (this.lookupd) {
-      return nsqlookup(this.lookupd).then((nodes) => {
-        return Promise.map(nodes, (node) => {
-          return this.connectNsqd(node.broadcast_address, node.tcp_port, this.opts);
-        }).then(() => {
-          return this.conns;
-        }, (error) => {
-          debug('connect to nsqd failed: %s', error);
-          throw error;
-        });
-      }, (errors) => {
-        debug('lookup errors %j', errors);
-        throw errors;
+    if (this.lookupdCluster) {
+      return this.lookupdCluster.nodes().map((node) => {
+        return this.connectNsqd(node.broadcast_address, node.tcp_port, this.opts);
+      }).then(() => {
+        return this.conns;
       }).asCallback(callback);
     }
 

--- a/lib/api/Base.js
+++ b/lib/api/Base.js
@@ -7,11 +7,17 @@ const Base = require('lib-rest').Base;
 module.exports = class NsqBase extends Base {
 
   post(key, qs, json) {
-    return this.api.post(key).qs(qs).json(json).request().spread(this.errHandler);
+    if (typeof json === 'string') {
+      return this.api.post(key).qs(qs).json(false).body(json).request().spread(this.errHandler)
+        .then(this.betterBody, this.betterError);
+    }
+    return this.api.post(key).qs(qs).json(json).request().spread(this.errHandler)
+      .then(this.betterBody, this.betterError);
   }
 
   get(key, qs) {
-    return this.api.get(key).qs(qs).request().spread(this.errHandler);
+    return this.api.get(key).qs(qs).request().spread(this.errHandler)
+      .then(this.betterBody, this.betterError);
   }
 
   /**
@@ -34,6 +40,29 @@ module.exports = class NsqBase extends Base {
         return this.ping(max);
       });
     });
+  }
+
+  /**
+   * For backwards compatibilities.
+   */
+  betterError(err) {
+    if (err.status_txt != null) {
+      err.message = err.status_txt;
+      if (err.status_txt.indexOf('NOT_FOUND') >= 0) {
+        err.statusCode = err.status_code = 404;
+      }
+    }
+    throw err;
+  }
+
+  /**
+   * For backwards compatibilities.
+   */
+  betterBody(args) {
+    if (args[1] != null && args[1].data != null) {
+      args[1] = args[1].data;
+    }
+    return args;
   }
 
 };

--- a/lib/api/Lookupd.js
+++ b/lib/api/Lookupd.js
@@ -21,11 +21,11 @@ module.exports = class Lookupd extends Base {
   }
 
   deleteTopic(topic) {
-    return this.post('delete_topic', { topic });
+    return this.post('topic/delete', { topic });
   }
 
   deleteChannel(topic, channel) {
-    return this.post('delete_channel', { topic, channel });
+    return this.post('channel/delete', { topic, channel });
   }
 
 };

--- a/lib/api/Lookupd.js
+++ b/lib/api/Lookupd.js
@@ -2,7 +2,7 @@
 
 const Base = require('./Base');
 
-module.exports = class Nsqlookupd extends Base {
+module.exports = class Lookupd extends Base {
 
   lookup(topic) {
     return this.get('lookup', { topic });
@@ -18,6 +18,14 @@ module.exports = class Nsqlookupd extends Base {
 
   nodes() {
     return this.get('nodes');
+  }
+
+  deleteTopic(topic) {
+    return this.post('delete_topic', { topic });
+  }
+
+  deleteChannel(topic, channel) {
+    return this.post('delete_channel', { topic, channel });
   }
 
 };

--- a/lib/api/LookupdCluster.js
+++ b/lib/api/LookupdCluster.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const Promise = require('bluebird');
+
+const Lookupd = require('./Lookupd');
+
+/**
+ * Multiple NSQ Lookupd.
+ */
+module.exports = class LookupdCluster {
+
+  constructor(options) {
+    if (Array.isArray(options)) {
+      options = { lookupdHTTPAddresses: options };
+    } else if (typeof options === 'string') {
+      options = { lookupdHTTPAddresses: [options] };
+    }
+    if (!Array.isArray(options.lookupdHTTPAddresses) || options.lookupdHTTPAddresses.length === 0) {
+      throw new Error('The option lookupdHTTPAddresses is required');
+    }
+    this._options = options;
+    this._lookupds = options.lookupdHTTPAddresses.map(toURL).map((address) => {
+      return new Lookupd(address);
+    });
+  }
+
+  // lookup(topic) {}
+
+  // topics() {}
+
+  // channels(topic) {}
+
+  nodes() {
+    const set = {};
+    return Promise.map(this._lookupds, (lookupd) => {
+      return lookupd.nodes().get(1).get('data').get('producers');
+    }).reduce((res, nodes) => {
+      return Promise.reduce(nodes, notNull, res);
+    }, []).filter((node) => {
+      // Dedupe.
+      const address = node.broadcast_address + ':' + node.tcp_port;
+      set[address] = set[address] == null;
+      return set[address];
+    }, { concurrency: 1 });
+  }
+
+};
+
+/**
+ * Reduce helper.
+ */
+function notNull(res, node) {
+  if (node != null) {
+    res.push(node);
+  }
+  return res;
+}
+
+/**
+ * Map helper.
+ */
+function toURL(address) {
+  if (address.indexOf('http') === 0) {
+    return address;
+  }
+  return 'http://' + address;
+}

--- a/lib/api/LookupdCluster.js
+++ b/lib/api/LookupdCluster.js
@@ -33,7 +33,7 @@ module.exports = class LookupdCluster {
   nodes() {
     const set = {};
     return Promise.map(this._lookupds, (lookupd) => {
-      return lookupd.nodes().get(1).get('data').get('producers');
+      return lookupd.nodes().get(1).get('producers');
     }).reduce((res, nodes) => {
       return Promise.reduce(nodes, notNull, res);
     }, []).filter((node) => {

--- a/lib/api/Nsqd.js
+++ b/lib/api/Nsqd.js
@@ -20,4 +20,16 @@ module.exports = class Nsqd extends Base {
     return this.post('topic/empty', { topic });
   }
 
+  createChannel(topic, channel) {
+    return this.post('channel/create', { topic, channel });
+  }
+
+  deleteChannel(topic, channel) {
+    return this.post('channel/delete', { topic, channel });
+  }
+
+  emptyChannel(topic, channel) {
+    return this.post('channel/empty', { topic, channel });
+  }
+
 };

--- a/package.json
+++ b/package.json
@@ -23,25 +23,24 @@
   },
   "homepage": "https://github.com/Wiredcraft/nsq-strategies#readme",
   "dependencies": {
-    "bluebird": "^3.4.7",
-    "debug": "^2.6.1",
+    "bluebird": "^3.5.0",
+    "debug": "^2.6.3",
     "file-register": "^0.1.0",
     "lib-rest": "^0.1.4",
-    "nsq-lookup": "1.0.2",
     "nsqjs": "^0.7.12",
     "promise-retry": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "coveralls": "^2.11.16",
+    "coveralls": "^2.13.0",
     "istanbul": "^0.4.5",
     "jscs": "^3.0.7",
     "jshint": "^2.9.4",
     "mocha": "^3.2.0",
     "once": "^1.4.0",
-    "randexp": "^0.4.4",
-    "request": "^2.79.0",
+    "randexp": "^0.4.5",
+    "request": "^2.81.0",
     "retry": "^0.10.1",
-    "should": "^11.2.0"
+    "should": "^11.2.1"
   }
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -5,6 +5,7 @@ const randexp = require('randexp').randexp;
 
 const nsqdHTTPAddress = 'http://localhost:9021';
 const lookupdHTTPAddress = 'http://localhost:9001';
+const lookupdHTTPAddresses = ['http://localhost:9001', 'http://localhost:9011'];
 const TOPIC = randexp(/\w{8}/);
 const CHANNEL = randexp(/\w{8}/);
 
@@ -220,6 +221,37 @@ describe('API libs', () => {
       return lookupd.deleteTopic(TOPIC).spread((res, body) => {
         body.should.be.Object();
         body.should.have.property('status_txt', 'OK');
+      });
+    });
+  });
+
+  describe('LookupdCluster', () => {
+    let LookupdCluster;
+    let cluster;
+
+    it('should be there', () => {
+      lib.should.have.property('api').which.is.Object();
+      lib.api.should.have.property('LookupdCluster').which.is.Function();
+      LookupdCluster = lib.api.LookupdCluster;
+    });
+
+    it('can build an instance with one address', () => {
+      cluster = new LookupdCluster(lookupdHTTPAddress);
+    });
+
+    it('can list all nodes', () => {
+      return cluster.nodes().then((res) => {
+        res.should.be.Array().with.length(3);
+      });
+    });
+
+    it('can build an instance with two addresses', () => {
+      cluster = new LookupdCluster(lookupdHTTPAddresses);
+    });
+
+    it('can list all nodes', () => {
+      return cluster.nodes().then((res) => {
+        res.should.be.Array().with.length(3);
       });
     });
   });

--- a/test/consumer.test.js
+++ b/test/consumer.test.js
@@ -1,43 +1,48 @@
 'use strict';
 
 const expect = require('chai').expect;
-const request = require('request');
+// const request = require('request');
 const randexp = require('randexp').randexp;
 
-const Consumer = require('../index').Consumer;
+const lib = require('../');
 
 const removeTopicFromAllNsqd = require('./helper').removeTopicFromAllNsqd;
 
-describe('consumer', function() {
-  this.timeout(5000);
-  const send = (topic, msg, cb) => {
-    const option = {
-      uri: `http://localhost:9031/put?topic=${topic}`,
-      method: 'POST',
-      body: msg
-    };
-    request(option, (e, res, body) => {
-      cb(e);
-    });
-  };
+const nsqdHTTPAddress = 'http://localhost:9031';
+const lookupdHTTPAddresses = ['http://localhost:9001', 'http://localhost:9011'];
+
+describe('Consumer', () => {
+  let Consumer;
+  let Nsqd;
+  let nsqd;
+
+  before(() => {
+    Nsqd = lib.api.Nsqd;
+    nsqd = new Nsqd(nsqdHTTPAddress);
+  });
+
+  it('should be there', () => {
+    lib.should.have.property('Consumer').which.is.Function();
+    Consumer = lib.Consumer;
+  });
 
   it('should receive message successfully', (done) => {
     const topic = randexp(/Consume-([a-z]{8})/);
-    send(topic, 'hello nsq', () => {
+    nsqd.publish(topic, 'hello nsq').then(() => {
       const c = new Consumer(topic, 'ipsum', {
-        lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011']
+        lookupdHTTPAddresses
       });
       c.consume((msg) => {
         expect(msg.body.toString()).to.be.equal('hello nsq');
         msg.finish();
         removeTopicFromAllNsqd(topic, done);
       });
-    });
+    }, done);
   });
 
   it('should throw error if connect after auto connection', (done) => {
     const c = new Consumer('anytopic', 'ipsum', {
-      lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011'],
+      lookupdHTTPAddresses,
       autoConnect: true
     });
     try {
@@ -50,9 +55,9 @@ describe('consumer', function() {
 
   it('should receive message successfully with connect manuallly', (done) => {
     const topic = randexp(/Consume-([a-z]{8})/);
-    send(topic, 'hello nsq', () => {
+    nsqd.publish(topic, 'hello nsq').then(() => {
       const c = new Consumer(topic, 'ipsum', {
-        lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011'],
+        lookupdHTTPAddresses,
         autoConnect: false
       });
       c.connect();
@@ -61,15 +66,14 @@ describe('consumer', function() {
         msg.finish();
         removeTopicFromAllNsqd(topic, done);
       });
-    });
+    }, done);
   });
 
-  it('should be able to requeu message', function(done) {
-    this.timeout(8000);
+  it('should be able to requeu message', (done) => {
     const topic = randexp(/Consume-([a-z]{8})/);
-    send(topic, 'test requeue', () => {
+    nsqd.publish(topic, 'test requeue').then(() => {
       const c = new Consumer(topic, 'sit', {
-        lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011']
+        lookupdHTTPAddresses
       });
       let n = 0;
       c.consume((msg) => {
@@ -83,7 +87,7 @@ describe('consumer', function() {
           done();
         }
       });
-    });
+    }, done);
   });
 
 });

--- a/test/producer.test.js
+++ b/test/producer.test.js
@@ -29,7 +29,7 @@ const runOnce = (callback) => {
 
 const TOPIC = randexp(/\w{8}/);
 
-describe('producer', function() {
+describe('producer', () => {
 
   beforeEach((done) => {
     removeTopicFromAllNsqd(TOPIC, done);
@@ -39,7 +39,7 @@ describe('producer', function() {
     removeTopicFromAllNsqd(TOPIC, done);
   });
 
-  it('should be able to publish to single nsqd', function(done) {
+  it('should be able to publish to single nsqd', (done) => {
     const p = new Producer({
       nsqdHost: 'localhost',
       tcpPort: 9030
@@ -58,7 +58,7 @@ describe('producer', function() {
     });
   });
 
-  it('should be able to publish to lookup', function(done) {
+  it('should be able to publish to lookup', (done) => {
     const p = new Producer({
       lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011']
     });
@@ -76,17 +76,18 @@ describe('producer', function() {
     });
   });
 
-  it('should be called with error if lookup fails', function(done) {
+  it('should be called with error if lookup fails', () => {
     const p = new Producer({
       lookupdHTTPAddresses: ['localhost:9091', 'localhost:9092'] //non-existed lookupd
     });
-    p.connect((errors) => {
-      expect(errors).to.be.an('array');
-      done();
+    return p.connect().then(() => {
+      throw new Error('expected an error');
+    }, (err) => {
+      expect(err).to.exist;
     });
   });
 
-  it('should be able to close', function(done) {
+  it('should be able to close', (done) => {
     const p = new Producer({
       lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011']
     });
@@ -99,7 +100,7 @@ describe('producer', function() {
     });
   });
 
-  it('should be able to play round robin', function(done) {
+  it('should be able to play round robin', (done) => {
     const p = new Producer({
       lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011']
     });
@@ -124,7 +125,7 @@ describe('producer', function() {
     });
   });
 
-  it('should be able to play fanout', function(done) {
+  it('should be able to play fanout', (done) => {
     const p = new Producer({
       lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011']
     }, { strategy: Producer.FAN_OUT });
@@ -196,7 +197,7 @@ describe('producer', function() {
     });
   });
 
-  describe('reconnect', function() {
+  describe('reconnect', () => {
 
     beforeEach((done) => {
       removeTopicFromAllNsqd(TOPIC, done);
@@ -262,7 +263,7 @@ describe('producer', function() {
       });
     });
 
-    it('should be able to produce after reconnection', function(done) {
+    it('should be able to produce after reconnection', (done) => {
       const p = new Producer({
         nsqdHost: 'localhost',
         tcpPort: 9040
@@ -295,7 +296,7 @@ describe('producer', function() {
     });
   });
 
-  describe('Producer strategies', function() {
+  describe('Producer strategies', () => {
     describe('connect nsqd directly', () => {
 
       beforeEach((done) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,13 @@ abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
+ajv@^4.9.1:
+  version "4.11.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.5.tgz#b6ee74657b993a01dce44b7944d56f485828d5bd"
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -133,10 +140,6 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
-batch@~0.5.0:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/batch/-/batch-0.5.3.tgz#3f3414f380321743bfc1042f9a83ff1d5824d464"
-
 bcrypt-pbkdf@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz#3ca76b85241c7170bf7d9703e7b9aa74630040d4"
@@ -157,9 +160,9 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.4.7:
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+bluebird@^3.4.7, bluebird@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 boom@2.x.x:
   version "2.10.1"
@@ -189,6 +192,10 @@ camelcase@^1.0.2:
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -244,6 +251,10 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -292,10 +303,6 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-cookiejar@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-1.3.0.tgz#dd00b35679021e99cbd4e855b9ad041913474765"
-
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -304,9 +311,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-coveralls@^2.11.16:
-  version "2.11.16"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.11.16.tgz#da9061265142ddee954f68379122be97be8ab4b1"
+coveralls@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.0.tgz#df933876e8c6f478efb04f4d3ab70dc96b7e5a8e"
   dependencies:
     js-yaml "3.6.1"
     lcov-parse "0.0.10"
@@ -354,15 +361,11 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@^2.2.0, debug@^2.6.0, debug@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+debug@^2.2.0, debug@^2.6.0, debug@^2.6.1, debug@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
-
-debug@~0.7.2:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
 decamelize@^1.0.0:
   version "1.2.0"
@@ -445,10 +448,6 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
-
-emitter-component@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/emitter-component/-/emitter-component-1.0.0.tgz#f04dd18fc3dc3e9a74cbc0f310b088666e4c016f"
 
 entities@1.0:
   version "1.0.0"
@@ -553,10 +552,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-formidable@1.0.14:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.14.tgz#2b3f4c411cbb5fdd695c44843e2a23514a43231a"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -664,6 +659,10 @@ handlebars@^4.0.1:
   optionalDependencies:
     uglify-js "^2.6"
 
+har-schema@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
+
 har-validator@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
@@ -672,6 +671,13 @@ har-validator@~2.0.6:
     commander "^2.9.0"
     is-my-json-valid "^2.12.4"
     pinkie-promise "^2.0.0"
+
+har-validator@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
+  dependencies:
+    ajv "^4.9.1"
+    har-schema "^1.0.5"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -914,6 +920,12 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -921,6 +933,10 @@ json-stringify-safe@~5.0.1:
 json3@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
 jsonlint@~1.6.2:
   version "1.6.2"
@@ -1041,10 +1057,6 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-methods@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-0.0.1.tgz#277c90f8bef39709645a8371c51c3b6c648e068c"
-
 mime-db@~1.26.0:
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.26.0.tgz#eaffcd0e4fc6935cf8134da246e2e6c35305adff"
@@ -1054,10 +1066,6 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee"
   dependencies:
     mime-db "~1.26.0"
-
-mime@1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.5.tgz#9eed073022a8bf5e16c8566c6867b8832bfbfa13"
 
 "minimatch@2 || 3", minimatch@^3.0.2, minimatch@~3.0.0, minimatch@~3.0.2:
   version "3.0.3"
@@ -1182,14 +1190,6 @@ not-empty-object@^1.0.0:
     gauge "~2.6.0"
     set-blocking "~2.0.0"
 
-nsq-lookup@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nsq-lookup/-/nsq-lookup-1.0.2.tgz#bd22bb42b0bec794f335d0fe765209a1f27fd4cb"
-  dependencies:
-    batch "~0.5.0"
-    superagent "~0.16.0"
-    superagent-retry "^0.5.1"
-
 nsqjs@^0.7.12:
   version "0.7.13"
   resolved "https://registry.yarnpkg.com/nsqjs/-/nsqjs-0.7.13.tgz#08adb62bc1e7cc6954c402d3b2772ad2ec8dc5fc"
@@ -1269,6 +1269,10 @@ pathval@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-0.1.1.tgz#08f911cdca9cce5942880da7817bc0b723b66d82"
 
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -1324,17 +1328,17 @@ purest@^3.0.1:
     "@request/api" "^0.6.0"
     extend "^3.0.0"
 
-qs@0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-0.6.5.tgz#294b268e4b0d4250f6dde19b3b8b34935dff14ef"
-
 qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
-randexp@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.4.tgz#ba68265f4a9f9e85f5814d34e160291f939f168e"
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+randexp@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.5.tgz#ffe3a80c3f666cd71e6b008e477e584c1a32ff3e"
   dependencies:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
@@ -1366,10 +1370,6 @@ readable-stream@1.1:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-reduce-component@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/reduce-component/-/reduce-component-1.0.1.tgz#e0c93542c574521bea13df0f9488ed82ab77c5da"
-
 regenerator-runtime@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz#257f41961ce44558b18f7814af48c17559f9faeb"
@@ -1378,7 +1378,34 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-request@2, request@2.79.0, request@^2.79.0:
+request@2, request@^2.79.0, request@^2.81.0:
+  version "2.81.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~4.2.1"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    performance-now "^0.2.0"
+    qs "~6.4.0"
+    safe-buffer "^5.0.1"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.0.0"
+
+request@2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -1435,6 +1462,10 @@ rimraf@2, rimraf@2.x.x:
   dependencies:
     glob "^7.0.5"
 
+safe-buffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
 "semver@2.x || 3.x || 4 || 5":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -1479,9 +1510,9 @@ should-util@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/should-util/-/should-util-1.0.0.tgz#c98cda374aa6b190df8ba87c9889c2b4db620063"
 
-should@^11.2.0:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/should/-/should-11.2.0.tgz#7afca3182c234781d786d2278a87805b5ecf0409"
+should@^11.2.1:
+  version "11.2.1"
+  resolved "https://registry.yarnpkg.com/should/-/should-11.2.1.tgz#90f55145552d01cfc200666e4e818a1c9670eda2"
   dependencies:
     should-equal "^1.0.0"
     should-format "^3.0.2"
@@ -1613,23 +1644,6 @@ strip-json-comments@1.0.x, strip-json-comments@~1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
 
-superagent-retry@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/superagent-retry/-/superagent-retry-0.5.1.tgz#6797e863db3875ca673b51314a28f1d98e0c8b1a"
-
-superagent@~0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-0.16.0.tgz#f38df4a476565dffdbaa07764b81a19f0ab38a4e"
-  dependencies:
-    cookiejar "1.3.0"
-    debug "~0.7.2"
-    emitter-component "1.0.0"
-    formidable "1.0.14"
-    methods "0.0.1"
-    mime "1.2.5"
-    qs "0.6.5"
-    reduce-component "1.0.1"
-
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
@@ -1667,6 +1681,12 @@ tough-cookie@~2.3.0:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
 
 tunnel-agent@~0.4.1:
   version "0.4.3"


### PR DESCRIPTION
Good to go for dropping `nsq-lookup`, however `nsqjs` also has a similar problem, and to upgrade to NSQ 1.0 we need to either wait for a fix or find a workaround.