### PR TITLE
fix: prevent infinite loop when all nsqd nodes are down

### DIFF
--- a/lib/Producer.js
+++ b/lib/Producer.js
@@ -29,11 +29,16 @@ class Producer {
     if (this.lookupdCluster) {
       return this.lookupdCluster
         .nodes()
-        .map(node => {
-          return this.connectNsqd(node.broadcast_address, node.tcp_port, this.opts);
-        })
-        .then(() => {
-          return this.conns;
+        .then(nodes => {
+          if (nodes.length == 0) {
+            return Promise.reject('No nsqd nodes are discovered from the configured lookupd addresses');
+          } else {
+            return Promise.map(nodes, node => {
+              return this.connectNsqd(node.broadcast_address, node.tcp_port, this.opts);
+            }).then(() => {
+              return this.conns;
+            });
+          }
         })
         .asCallback(callback);
     }

--- a/lib/Producer.js
+++ b/lib/Producer.js
@@ -31,7 +31,7 @@ class Producer {
         .nodes()
         .then(nodes => {
           if (nodes.length == 0) {
-            return Promise.reject('No nsqd nodes are discovered from the configured lookupd addresses');
+            return Promise.reject(new Error('No nsqd nodes are discovered from the configured lookupd addresses'));
           } else {
             return Promise.map(nodes, node => {
               return this.connectNsqd(node.broadcast_address, node.tcp_port, this.opts);

--- a/test/producer.test.js
+++ b/test/producer.test.js
@@ -185,7 +185,7 @@ describe('producer', () => {
       },
       err => {
         expect(err).to.exist;
-        expect(err).to.contain('No nsqd nodes are discovered');
+        expect(err.message).to.contain('No nsqd nodes are discovered');
       }
     );
   });

--- a/test/producer.test.js
+++ b/test/producer.test.js
@@ -174,6 +174,22 @@ describe('producer', () => {
     );
   });
 
+  it('should be called with error if lookup returns no nodes during connect', () => {
+    const p = new Producer({
+      lookupdHTTPAddresses: ['localhost:9001', 'localhost:9011'] // non-existed lookupd
+    });
+    p.lookupdCluster.nodes = () => Promise.resolve([]);
+    return p.connect().then(
+      () => {
+        throw new Error('expected an error');
+      },
+      err => {
+        expect(err).to.exist;
+        expect(err).to.contain('No nsqd nodes are discovered');
+      }
+    );
+  });
+
   it('should be able to receive comman slitted string', done => {
     const p = new Producer({
       lookupdHTTPAddresses: 'localhost:9001,localhost:9011'


### PR DESCRIPTION
Ticket:

* https://tools.adidas-group.com/jira/browse/CNCONF-2264